### PR TITLE
Add the ability to seek song time

### DIFF
--- a/src/components/Player.css
+++ b/src/components/Player.css
@@ -40,3 +40,8 @@ i.fas.fa-pause-circle {
 i:hover, svg:hover {
     transform: scale(1.3);
 }
+
+.music-timer-wrapper {
+	width: 100%;
+	height: 12px;
+}

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -62,12 +62,25 @@ const Player = ({
         if (selectedSongId > 0) {
             selectSongById(selectedSongId - 1);
         }
-    };
+	};
+	
     const onForwardClick = () => {
         if (selectedSongId < songs.length - 1) {
             selectSongById(selectedSongId + 1);
         }
-    };
+	};
+
+	const onTimeSeek = (e) => {
+		let target = document.getElementsByClassName("music-timer-wrapper")[0];
+
+		let rect = target.getBoundingClientRect();
+		let skipToPercent = (e.clientX - rect.left) / rect.right;
+		audioRef.current.currentTime = audioRef.current.duration * skipToPercent;
+		dispatch({
+			type: "SET_CURRENT_LOCATION",
+			payload: audioRef.current.currentTime,
+		});
+	}
 
     useEffect(() => {
         dispatch({ type: "PLAYER_STATE_SELECTED", payload: 1 });
@@ -82,8 +95,11 @@ const Player = ({
     }, [dispatch]);
 
     return (
-        <div id="player">
-            <SongTime />
+		<div id="player">
+			<div className="music-timer-wrapper" onClick={onTimeSeek}>
+				<SongTime />
+			</div>
+            
             <div
                 className="control"
                 id={shuffled ? `active` : null}

--- a/src/components/SongTime.css
+++ b/src/components/SongTime.css
@@ -5,8 +5,12 @@
     grid-row: 9/10;
 }
 
+.music-timer:hover {
+	height: 12px;
+}
+
 .completed {
-    height: 4px;
+    height: 100%;
     width: 60%;
     background-color: #2a8eb9;  
 }


### PR DESCRIPTION
This PR adds the ability to seek song time by clicking on the song progress bar in a desired position. The progress bar becomes bigger in height when hovered over so it's harder to missclick on the bar. You can see how this looks in the following screen recording.

https://user-images.githubusercontent.com/35216654/193642082-b22c9954-7c1c-4eb0-8674-458d30da8188.mp4

